### PR TITLE
fix: プロジェクト入力欄の初回フォーカスが当たらない問題を修正 + Playwright E2E テスト追加

### DIFF
--- a/.claude/skills/release/skill.md
+++ b/.claude/skills/release/skill.md
@@ -1,0 +1,87 @@
+---
+name: release
+description: Release a new version of gcp-selector. Run this skill when the user says "リリースして", "release", or asks to publish. Version is injected automatically by CI from the tag name — no version bump commit needed. Guides through gh release create → CI attaches zip → Chrome Web Store upload reminder.
+---
+
+# gcp-selector Release
+
+The version is automatically injected by CI from the tag name. **No version bump commit is needed in PRs.**
+
+## Prerequisites
+
+- All changes to release are merged into `main`
+- `gh` CLI is authenticated (`gh auth status`)
+
+## Steps
+
+### Step 1: Determine the version
+
+Check the previous release and confirm the next version with the user.
+
+```bash
+gh release list --limit 5
+```
+
+Versioning guide:
+- Bug fixes only → patch (e.g. `1.0.0` → `1.0.1`)
+- New features → minor (e.g. `1.0.0` → `1.1.0`)
+- Breaking changes → major (e.g. `1.0.0` → `2.0.0`)
+
+### Step 2: Create a GitHub Release
+
+Use `--generate-notes` to auto-generate release notes from PRs merged since the last release.
+
+```bash
+gh release create vX.X.X \
+  --title "vX.X.X" \
+  --generate-notes \
+  --target main
+```
+
+This will:
+1. Create tag `vX.X.X` on the latest commit of `main`
+2. Publish the GitHub Release
+3. Trigger the CI **Release** workflow automatically
+
+### Step 3: Wait for CI to complete
+
+```bash
+gh run list --workflow=release.yml --limit 3
+```
+
+Once CI finishes, `gcp-selector.zip` with the injected version will be attached to the release.
+
+### Step 4: Upload to Chrome Web Store (manual)
+
+```bash
+# Open the release page in browser
+gh release view vX.X.X --web
+```
+
+1. Download `gcp-selector.zip` from the release page
+2. Open [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole)
+3. Select **GCP Selector** → **Package** → **Upload new package**
+4. Submit for review
+
+## Edit release notes
+
+```bash
+gh release edit vX.X.X --notes "Custom release notes"
+# or in browser
+gh release view vX.X.X --web
+```
+
+## Troubleshooting
+
+### If CI fails
+
+```bash
+gh run list --workflow=release.yml --limit 3
+gh run view <run-id> --log-failed
+```
+
+### Delete a release (including its tag)
+
+```bash
+gh release delete vX.X.X --yes --cleanup-tag
+```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,7 @@ jobs:
       - name: Build and package
         run: npm run zip
 
-      - name: Create GitHub Release
+      - name: Upload zip to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: gcp-selector.zip
-          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build and package
+        run: npm run zip
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: gcp-selector.zip
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,16 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Inject version into manifest.json and package.json
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          jq --arg v "$VERSION" '.version = $v' manifest.json > manifest.tmp.json && mv manifest.tmp.json manifest.json
+          jq --arg v "$VERSION" '.version = $v' package.json > package.tmp.json && mv package.tmp.json package.json
+
       - name: Build and package
         run: npm run zip
 

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ yarn-error.log*
 .npm/
 
 # Claude Code specific files
-.claude/
+.claude/settings.local.json
 CLAUDE.md
 
 gcp-selector.zip

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ yarn-error.log*
 CLAUDE.md
 
 gcp-selector.zip
+
+# Playwright
+/playwright-report
+/test-results

--- a/README.md
+++ b/README.md
@@ -140,20 +140,68 @@ The E2E suite covers:
 
 ## 🚀 Release
 
-Releases are triggered by pushing a version tag. CI will automatically run tests, build `gcp-selector.zip`, and create a GitHub Release with the zip attached.
+When a version tag is pushed, CI automatically runs tests, builds `gcp-selector.zip`, and attaches it to the GitHub Release.
 
-### Steps
+### Version numbering
 
-1. Update the version in `manifest.json` and `package.json`
-2. Commit and push to `main`
-3. Push a version tag:
+This project follows [Semantic Versioning](https://semver.org/):
 
-```bash
-git tag v1.0.1
-git push origin v1.0.1
+| Change type | Example |
+|---|---|
+| Bug fix | `1.0.0` → `1.0.1` |
+| New feature | `1.0.0` → `1.1.0` |
+| Breaking change | `1.0.0` → `2.0.0` |
+
+> **Note:** `manifest.json` uses `major.minor.patch` (e.g. `1.0.1`), while the Chrome Web Store only shows `major.minor`.
+
+### Release steps
+
+#### 1. Update versions
+
+Edit the version field in both files:
+
+**`manifest.json`**
+```json
+{
+  "version": "1.0.1"
+}
 ```
 
-4. Download `gcp-selector.zip` from the [GitHub Release](../../releases) and upload it to the [Chrome Web Store](https://chrome.google.com/webstore/detail/gcp-selector/gdfiojnnhlfmkbghihllimpaanldflag) manually.
+**`package.json`**
+```json
+{
+  "version": "1.0.1"
+}
+```
+
+#### 2. Commit and push to `main`
+
+```bash
+git add manifest.json package.json
+git commit -m "chore: bump version to 1.0.1"
+git push origin main
+```
+
+#### 3. Create a GitHub Release
+
+1. Open the repository on GitHub and go to **Releases → Draft a new release**
+2. Click **"Choose a tag"** → type the new version (e.g. `v1.0.1`) → **"+ Create new tag"**
+3. Make sure the target is **`main`**
+4. Fill in the release title (e.g. `v1.0.1`) and write release notes
+5. Click **"Publish release"**
+
+This publishes the tag, which triggers the CI release workflow.
+
+#### 4. Wait for CI to attach the zip
+
+Go to **Actions** and wait for the **Release** workflow to complete (about 1–2 minutes). Once done, `gcp-selector.zip` will be attached to the release automatically.
+
+#### 5. Upload to Chrome Web Store
+
+1. Download `gcp-selector.zip` from the [GitHub Release](../../releases)
+2. Open the [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole)
+3. Select **GCP Selector** → **Package** → **Upload new package**
+4. Upload the zip and submit for review
 
 ## 📋 Requirements
 - Google Chrome browser

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The E2E suite covers:
 
 ## 🚀 Release
 
-When a version tag is pushed, CI automatically runs tests, builds `gcp-selector.zip`, and attaches it to the GitHub Release.
+**Versions are managed automatically by CI.** The version in `manifest.json` / `package.json` is not tracked in source — CI injects it from the tag name at build time. No version bump commit is needed in PRs.
 
 ### Version numbering
 
@@ -152,56 +152,42 @@ This project follows [Semantic Versioning](https://semver.org/):
 | New feature | `1.0.0` → `1.1.0` |
 | Breaking change | `1.0.0` → `2.0.0` |
 
-> **Note:** `manifest.json` uses `major.minor.patch` (e.g. `1.0.1`), while the Chrome Web Store only shows `major.minor`.
-
 ### Release steps
 
-#### 1. Update versions
+#### 1. Merge the PR
 
-Edit the version field in both files:
+Ensure all changes are merged into `main`. No version bump commit is needed.
 
-**`manifest.json`**
-```json
-{
-  "version": "1.0.1"
-}
-```
-
-**`package.json`**
-```json
-{
-  "version": "1.0.1"
-}
-```
-
-#### 2. Commit and push to `main`
+#### 2. Create a GitHub Release
 
 ```bash
-git add manifest.json package.json
-git commit -m "chore: bump version to 1.0.1"
-git push origin main
+# Check commits since the last release
+gh release list --limit 5
+
+# Create a release (auto-generates tag and release notes)
+gh release create v1.0.1 --generate-notes --target main
 ```
 
-#### 3. Create a GitHub Release
+Alternatively, via GitHub UI:
+1. **Releases → Draft a new release**
+2. **"Choose a tag"** → type the version (e.g. `v1.0.1`) → **"+ Create new tag"**
+3. Target: **`main`**
+4. Fill in release notes → **"Publish release"**
 
-1. Open the repository on GitHub and go to **Releases → Draft a new release**
-2. Click **"Choose a tag"** → type the new version (e.g. `v1.0.1`) → **"+ Create new tag"**
-3. Make sure the target is **`main`**
-4. Fill in the release title (e.g. `v1.0.1`) and write release notes
-5. Click **"Publish release"**
+#### 3. Wait for CI to attach the zip
 
-This publishes the tag, which triggers the CI release workflow.
+```bash
+gh run list --workflow=release.yml --limit 3
+```
 
-#### 4. Wait for CI to attach the zip
+Once CI completes, `gcp-selector.zip` with the version injected from the tag will be attached to the release automatically.
 
-Go to **Actions** and wait for the **Release** workflow to complete (about 1–2 minutes). Once done, `gcp-selector.zip` will be attached to the release automatically.
-
-#### 5. Upload to Chrome Web Store
+#### 4. Upload to Chrome Web Store (manual)
 
 1. Download `gcp-selector.zip` from the [GitHub Release](../../releases)
 2. Open the [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole)
 3. Select **GCP Selector** → **Package** → **Upload new package**
-4. Upload the zip and submit for review
+4. Submit for review
 
 ## 📋 Requirements
 - Google Chrome browser

--- a/README.md
+++ b/README.md
@@ -32,7 +32,14 @@ This project is a Chrome extension built with React + TypeScript.
 ├── package.json           # Project dependencies
 ├── tsconfig.json          # TypeScript configuration
 ├── webpack.config.js      # Webpack configuration
-├── jest.config.js         # Test configuration
+├── jest.config.js         # Jest configuration
+├── playwright.config.ts   # Playwright configuration
+│
+├── e2e/                   # E2E tests (Playwright)
+│   ├── fixtures.ts        # Custom fixtures for extension loading
+│   ├── popup.spec.ts      # Popup tests
+│   ├── option.spec.ts     # Option page tests
+│   └── integration.spec.ts # Cross-page integration tests
 │
 ├── src/                   # Source code
 │   ├── popup/             # Popup screen
@@ -83,7 +90,7 @@ This project is a Chrome extension built with React + TypeScript.
 - **Language**: TypeScript
 - **UI**: react-select, FontAwesome
 - **Build Tool**: Webpack
-- **Testing**: Jest, React Testing Library
+- **Testing**: Jest, React Testing Library, Playwright
 - **Package Manager**: npm
 
 ### 🚀 Key Features
@@ -108,6 +115,45 @@ This command starts webpack in watch mode, automatically rebuilding when files c
 2. Enable "Developer mode" (toggle in top right)
 3. Click "Load unpacked" and select the `dist` folder
 4. The extension icon will appear in your Chrome toolbar
+
+## 🧪 Testing
+
+### Unit Tests
+
+```bash
+npm test
+```
+
+### E2E Tests (Playwright)
+
+E2E tests run against the actual built extension in a real Chromium browser.
+
+```bash
+npm run test:e2e        # Build and run all E2E tests
+npm run test:e2e:ui     # Run with Playwright UI mode
+```
+
+The E2E suite covers:
+- **Popup**: auto-focus, keyboard navigation, URL generation, settings navigation
+- **Option page**: add/delete projects, validation, Enter key support
+- **Integration**: cross-page storage consistency, full setup flow
+
+## 🚀 Release
+
+Releases are triggered by pushing a version tag. CI will automatically run tests, build `gcp-selector.zip`, and create a GitHub Release with the zip attached.
+
+### Steps
+
+1. Update the version in `manifest.json` and `package.json`
+2. Commit and push to `main`
+3. Push a version tag:
+
+```bash
+git tag v1.0.1
+git push origin v1.0.1
+```
+
+4. Download `gcp-selector.zip` from the [GitHub Release](../../releases) and upload it to the [Chrome Web Store](https://chrome.google.com/webstore/detail/gcp-selector/gdfiojnnhlfmkbghihllimpaanldflag) manually.
 
 ## 📋 Requirements
 - Google Chrome browser

--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ Once CI completes, `gcp-selector.zip` with the version injected from the tag wil
 3. Select **GCP Selector** → **Package** → **Upload new package**
 4. Submit for review
 
+## 🤖 Claude Skills
+
+This project includes [Claude Code](https://claude.ai/code) skills under `.claude/skills/`. If you use Claude Code, these skills are available as slash commands:
+
+| Skill | Command | Description |
+|---|---|---|
+| Release | `/release` | Guides through the full release process — create a GitHub Release, wait for CI, and upload to Chrome Web Store |
+
 ## 📋 Requirements
 - Google Chrome browser
 - Account with access to GCP console

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -4,12 +4,15 @@ import os from 'os';
 import path from 'path';
 
 const EXTENSION_PATH = path.join(__dirname, '../dist');
+export const STORAGE_KEY_PROJECT_IDS = 'storageKeyProjectIDs';
 
 export const test = base.extend<{
   context: BrowserContext;
   extensionId: string;
+  popupUrl: string;
+  optionUrl: string;
+  seedProjects: (projects: string[]) => Promise<void>;
 }>({
-  // Fresh browser profile per test to avoid state pollution
   context: async ({}, use) => {
     const tmpProfile = fs.mkdtempSync(path.join(os.tmpdir(), 'gcp-selector-e2e-'));
     const context = await chromium.launchPersistentContext(tmpProfile, {
@@ -26,7 +29,6 @@ export const test = base.extend<{
   },
 
   extensionId: async ({ context }, use) => {
-    // Detect extension ID via chrome://extensions
     const page = await context.newPage();
     await page.goto('chrome://extensions');
     await page.waitForTimeout(1000);
@@ -42,9 +44,29 @@ export const test = base.extend<{
       return '';
     });
     await page.close();
-
     if (!id) throw new Error('GCP Selector extension not found. Run `npm run build` first.');
     await use(id);
+  },
+
+  popupUrl: async ({ extensionId }, use) => {
+    await use(`chrome-extension://${extensionId}/popup/popup.html`);
+  },
+
+  optionUrl: async ({ extensionId }, use) => {
+    await use(`chrome-extension://${extensionId}/option/option.html`);
+  },
+
+  seedProjects: async ({ context, popupUrl }, use) => {
+    const seed = async (projects: string[]) => {
+      const page = await context.newPage();
+      await page.goto(popupUrl);
+      await page.evaluate(
+        ({ key, projects }) => chrome.storage.local.set({ [key]: projects }),
+        { key: STORAGE_KEY_PROJECT_IDS, projects }
+      );
+      await page.close();
+    };
+    await use(seed);
   },
 });
 

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,51 @@
+import { test as base, chromium, BrowserContext } from '@playwright/test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const EXTENSION_PATH = path.join(__dirname, '../dist');
+
+export const test = base.extend<{
+  context: BrowserContext;
+  extensionId: string;
+}>({
+  // Fresh browser profile per test to avoid state pollution
+  context: async ({}, use) => {
+    const tmpProfile = fs.mkdtempSync(path.join(os.tmpdir(), 'gcp-selector-e2e-'));
+    const context = await chromium.launchPersistentContext(tmpProfile, {
+      headless: false,
+      args: [
+        `--disable-extensions-except=${EXTENSION_PATH}`,
+        `--load-extension=${EXTENSION_PATH}`,
+        '--no-sandbox',
+      ],
+    });
+    await use(context);
+    await context.close();
+    fs.rmSync(tmpProfile, { recursive: true });
+  },
+
+  extensionId: async ({ context }, use) => {
+    // Detect extension ID via chrome://extensions
+    const page = await context.newPage();
+    await page.goto('chrome://extensions');
+    await page.waitForTimeout(1000);
+    const id = await page.evaluate(() => {
+      const items = document.querySelector('extensions-manager')
+        ?.shadowRoot?.querySelector('extensions-item-list')
+        ?.shadowRoot?.querySelectorAll('extensions-item');
+      if (!items) return '';
+      for (const item of items) {
+        const name = item.shadowRoot?.querySelector('#name')?.textContent ?? '';
+        if (name.includes('GCP')) return item.getAttribute('id') ?? '';
+      }
+      return '';
+    });
+    await page.close();
+
+    if (!id) throw new Error('GCP Selector extension not found. Run `npm run build` first.');
+    await use(id);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/e2e/integration.spec.ts
+++ b/e2e/integration.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from './fixtures';
+
+test.describe('ページ間連携', () => {
+  test('I-1: Option で追加したプロジェクトが Popup の選択肢に表示される', async ({
+    context,
+    popupUrl,
+    optionUrl,
+  }) => {
+    // Option ページでプロジェクトを追加
+    const optionPage = await context.newPage();
+    await optionPage.goto(optionUrl);
+    await optionPage.fill('.project-input', 'option-added-project');
+    await optionPage.click('.add-button');
+    await expect(
+      optionPage.locator('.project-item').filter({ hasText: 'option-added-project' })
+    ).toBeVisible();
+    await optionPage.close();
+
+    // Popup を開いてドロップダウンに表示されることを確認
+    const popupPage = await context.newPage();
+    await popupPage.goto(popupUrl);
+    await popupPage.waitForFunction(() => document.activeElement?.tagName === 'INPUT');
+
+    await popupPage.locator('.input-section').click();
+    await expect(
+      popupPage.locator('[class*="option"]').filter({ hasText: 'option-added-project' })
+    ).toBeVisible();
+  });
+
+  test('I-2: Option で削除したプロジェクトが Popup の選択肢から消える', async ({
+    context,
+    popupUrl,
+    optionUrl,
+    seedProjects,
+  }) => {
+    await seedProjects(['project-keep', 'project-remove']);
+
+    // Option ページで削除
+    const optionPage = await context.newPage();
+    await optionPage.goto(optionUrl);
+    await optionPage
+      .locator('.project-item')
+      .filter({ hasText: 'project-remove' })
+      .locator('.delete-button')
+      .click();
+    await expect(
+      optionPage.locator('.project-item').filter({ hasText: 'project-remove' })
+    ).not.toBeVisible();
+    await optionPage.close();
+
+    // Popup を開いて削除されたプロジェクトが表示されないことを確認
+    const popupPage = await context.newPage();
+    await popupPage.goto(popupUrl);
+    await popupPage.waitForFunction(() => document.activeElement?.tagName === 'INPUT');
+
+    await popupPage.locator('.input-section').click();
+    await expect(
+      popupPage.locator('[class*="option"]').filter({ hasText: 'project-remove' })
+    ).not.toBeVisible();
+    await expect(
+      popupPage.locator('[class*="option"]').filter({ hasText: 'project-keep' })
+    ).toBeVisible();
+  });
+
+  test('I-3: 初回セットアップフロー: Popup Settings → Option でプロジェクト追加 → Popup に反映', async ({
+    context,
+    popupUrl,
+    extensionId,
+  }) => {
+    // 1. Popup を開く（プロジェクト未登録）
+    const popupPage = await context.newPage();
+    await popupPage.goto(popupUrl);
+    await expect(popupPage.locator('.no-projects-message')).toBeVisible();
+
+    // 2. Settings ボタンで Option ページを開く
+    const newPagePromise = context.waitForEvent('page');
+    await popupPage.locator('.settings-button').click();
+    const optionPage = await newPagePromise;
+    expect(optionPage.url()).toContain(`chrome-extension://${extensionId}`);
+
+    // 3. Option ページでプロジェクトを追加
+    await optionPage.fill('.project-input', 'flow-test-project');
+    await optionPage.click('.add-button');
+    await expect(
+      optionPage.locator('.project-item').filter({ hasText: 'flow-test-project' })
+    ).toBeVisible();
+
+    // 4. Popup を再度開いてプロジェクトが選択肢に表示されることを確認
+    const popupPage2 = await context.newPage();
+    await popupPage2.goto(popupUrl);
+    await popupPage2.waitForFunction(() => document.activeElement?.tagName === 'INPUT');
+
+    await popupPage2.locator('.input-section').click();
+    await expect(
+      popupPage2.locator('[class*="option"]').filter({ hasText: 'flow-test-project' })
+    ).toBeVisible();
+  });
+});

--- a/e2e/integration.spec.ts
+++ b/e2e/integration.spec.ts
@@ -1,12 +1,12 @@
 import { test, expect } from './fixtures';
 
-test.describe('ページ間連携', () => {
-  test('I-1: Option で追加したプロジェクトが Popup の選択肢に表示される', async ({
+test.describe('Cross-page integration', () => {
+  test('I-1: project added in Options appears in Popup dropdown', async ({
     context,
     popupUrl,
     optionUrl,
   }) => {
-    // Option ページでプロジェクトを追加
+    // Add a project on the Option page
     const optionPage = await context.newPage();
     await optionPage.goto(optionUrl);
     await optionPage.fill('.project-input', 'option-added-project');
@@ -16,7 +16,7 @@ test.describe('ページ間連携', () => {
     ).toBeVisible();
     await optionPage.close();
 
-    // Popup を開いてドロップダウンに表示されることを確認
+    // Open Popup and verify the project appears in the dropdown
     const popupPage = await context.newPage();
     await popupPage.goto(popupUrl);
     await popupPage.waitForFunction(() => document.activeElement?.tagName === 'INPUT');
@@ -27,7 +27,7 @@ test.describe('ページ間連携', () => {
     ).toBeVisible();
   });
 
-  test('I-2: Option で削除したプロジェクトが Popup の選択肢から消える', async ({
+  test('I-2: project deleted in Options disappears from Popup dropdown', async ({
     context,
     popupUrl,
     optionUrl,
@@ -35,7 +35,7 @@ test.describe('ページ間連携', () => {
   }) => {
     await seedProjects(['project-keep', 'project-remove']);
 
-    // Option ページで削除
+    // Delete a project on the Option page
     const optionPage = await context.newPage();
     await optionPage.goto(optionUrl);
     await optionPage
@@ -48,7 +48,7 @@ test.describe('ページ間連携', () => {
     ).not.toBeVisible();
     await optionPage.close();
 
-    // Popup を開いて削除されたプロジェクトが表示されないことを確認
+    // Open Popup and verify the deleted project is gone
     const popupPage = await context.newPage();
     await popupPage.goto(popupUrl);
     await popupPage.waitForFunction(() => document.activeElement?.tagName === 'INPUT');
@@ -62,30 +62,30 @@ test.describe('ページ間連携', () => {
     ).toBeVisible();
   });
 
-  test('I-3: 初回セットアップフロー: Popup Settings → Option でプロジェクト追加 → Popup に反映', async ({
+  test('I-3: full setup flow: Popup Settings → add project in Options → reflected in Popup', async ({
     context,
     popupUrl,
     extensionId,
   }) => {
-    // 1. Popup を開く（プロジェクト未登録）
+    // 1. Open Popup with no projects registered
     const popupPage = await context.newPage();
     await popupPage.goto(popupUrl);
     await expect(popupPage.locator('.no-projects-message')).toBeVisible();
 
-    // 2. Settings ボタンで Option ページを開く
+    // 2. Open Options page via Settings button
     const newPagePromise = context.waitForEvent('page');
     await popupPage.locator('.settings-button').click();
     const optionPage = await newPagePromise;
     expect(optionPage.url()).toContain(`chrome-extension://${extensionId}`);
 
-    // 3. Option ページでプロジェクトを追加
+    // 3. Add a project on the Options page
     await optionPage.fill('.project-input', 'flow-test-project');
     await optionPage.click('.add-button');
     await expect(
       optionPage.locator('.project-item').filter({ hasText: 'flow-test-project' })
     ).toBeVisible();
 
-    // 4. Popup を再度開いてプロジェクトが選択肢に表示されることを確認
+    // 4. Reopen Popup and verify the project appears in the dropdown
     const popupPage2 = await context.newPage();
     await popupPage2.goto(popupUrl);
     await popupPage2.waitForFunction(() => document.activeElement?.tagName === 'INPUT');

--- a/e2e/option.spec.ts
+++ b/e2e/option.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from './fixtures';
 
-test.describe('Option ページ', () => {
-  test('O-1: プロジェクトを追加すると一覧に表示される', async ({
+test.describe('Option page', () => {
+  test('O-1: added project appears in the list', async ({
     context,
     optionUrl,
   }) => {
@@ -16,7 +16,7 @@ test.describe('Option ページ', () => {
     ).toBeVisible();
   });
 
-  test('O-2: 追加したプロジェクトはリロード後も残る', async ({
+  test('O-2: added project persists after reload', async ({
     context,
     optionUrl,
   }) => {
@@ -32,7 +32,7 @@ test.describe('Option ページ', () => {
     ).toBeVisible();
   });
 
-  test('O-3: 空の Project ID で追加するとエラーメッセージが表示される', async ({
+  test('O-3: shows error message when adding an empty project ID', async ({
     context,
     optionUrl,
   }) => {
@@ -47,7 +47,7 @@ test.describe('Option ページ', () => {
     );
   });
 
-  test('O-4: プロジェクトを削除すると一覧から消える', async ({
+  test('O-4: deleted project disappears from the list', async ({
     context,
     optionUrl,
     seedProjects,
@@ -70,7 +70,7 @@ test.describe('Option ページ', () => {
     ).toBeVisible();
   });
 
-  test('O-5: Enter キーでプロジェクトを追加できる', async ({
+  test('O-5: Enter key adds a project', async ({
     context,
     optionUrl,
   }) => {

--- a/e2e/option.spec.ts
+++ b/e2e/option.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from './fixtures';
+
+test.describe('Option ページ', () => {
+  test('O-1: プロジェクトを追加すると一覧に表示される', async ({
+    context,
+    optionUrl,
+  }) => {
+    const page = await context.newPage();
+    await page.goto(optionUrl);
+
+    await page.fill('.project-input', 'new-project-123');
+    await page.click('.add-button');
+
+    await expect(
+      page.locator('.project-item').filter({ hasText: 'new-project-123' })
+    ).toBeVisible();
+  });
+
+  test('O-2: 追加したプロジェクトはリロード後も残る', async ({
+    context,
+    optionUrl,
+  }) => {
+    const page = await context.newPage();
+    await page.goto(optionUrl);
+
+    await page.fill('.project-input', 'persistent-project');
+    await page.click('.add-button');
+    await page.reload();
+
+    await expect(
+      page.locator('.project-item').filter({ hasText: 'persistent-project' })
+    ).toBeVisible();
+  });
+
+  test('O-3: 空の Project ID で追加するとエラーメッセージが表示される', async ({
+    context,
+    optionUrl,
+  }) => {
+    const page = await context.newPage();
+    await page.goto(optionUrl);
+
+    await page.click('.add-button');
+
+    await expect(page.locator('.error-message')).toBeVisible();
+    await expect(page.locator('.error-message')).toContainText(
+      'Please enter a Project ID'
+    );
+  });
+
+  test('O-4: プロジェクトを削除すると一覧から消える', async ({
+    context,
+    optionUrl,
+    seedProjects,
+  }) => {
+    await seedProjects(['project-to-delete', 'project-to-keep']);
+    const page = await context.newPage();
+    await page.goto(optionUrl);
+
+    await page
+      .locator('.project-item')
+      .filter({ hasText: 'project-to-delete' })
+      .locator('.delete-button')
+      .click();
+
+    await expect(
+      page.locator('.project-item').filter({ hasText: 'project-to-delete' })
+    ).not.toBeVisible();
+    await expect(
+      page.locator('.project-item').filter({ hasText: 'project-to-keep' })
+    ).toBeVisible();
+  });
+
+  test('O-5: Enter キーでプロジェクトを追加できる', async ({
+    context,
+    optionUrl,
+  }) => {
+    const page = await context.newPage();
+    await page.goto(optionUrl);
+
+    await page.fill('.project-input', 'enter-key-project');
+    await page.keyboard.press('Enter');
+
+    await expect(
+      page.locator('.project-item').filter({ hasText: 'enter-key-project' })
+    ).toBeVisible();
+  });
+});

--- a/e2e/popup.spec.ts
+++ b/e2e/popup.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from './fixtures';
 
 const TEST_PROJECTS = ['test-project-alpha', 'test-project-beta'];
 
-test.describe('Popup - プロジェクト未登録', () => {
-  test('P-2: NoProjectsMessage が表示されフォーカスエラーが起きない', async ({
+test.describe('Popup - no projects registered', () => {
+  test('P-2: shows NoProjectsMessage without focus errors', async ({
     context,
     popupUrl,
   }) => {
@@ -15,12 +15,12 @@ test.describe('Popup - プロジェクト未登録', () => {
   });
 });
 
-test.describe('Popup - プロジェクトあり', () => {
+test.describe('Popup - with projects', () => {
   test.beforeEach(async ({ seedProjects }) => {
     await seedProjects(TEST_PROJECTS);
   });
 
-  test('P-1: ポップアップを開くとプロジェクト入力欄に自動フォーカスされる', async ({
+  test('P-1: project input is auto-focused on open', async ({
     context,
     popupUrl,
   }) => {
@@ -32,7 +32,7 @@ test.describe('Popup - プロジェクトあり', () => {
     expect(activeTag).toBe('INPUT');
   });
 
-  test('P-3: プロジェクト選択後にサービス入力欄へフォーカスが移る', async ({
+  test('P-3: focus moves to service input after project selection', async ({
     context,
     popupUrl,
   }) => {
@@ -40,11 +40,11 @@ test.describe('Popup - プロジェクトあり', () => {
     await page.goto(popupUrl);
     await page.waitForFunction(() => document.activeElement?.tagName === 'INPUT');
 
-    // プロジェクトを選択（ArrowDown でドロップダウンを開き Enter で確定）
+    // Open dropdown with ArrowDown and confirm with Enter
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
 
-    // RAF によるフォーカス移動を待機
+    // Wait for RAF-based focus transition
     await page.waitForFunction(
       () => !!document.activeElement?.closest('.service-section')
     );
@@ -55,7 +55,7 @@ test.describe('Popup - プロジェクトあり', () => {
     expect(isServiceFocused).toBe(true);
   });
 
-  test('P-4: プロジェクト＋サービス選択で新しいタブが開く', async ({
+  test('P-4: selecting project and service opens a new tab', async ({
     context,
     popupUrl,
   }) => {
@@ -65,14 +65,14 @@ test.describe('Popup - プロジェクトあり', () => {
 
     const newPagePromise = context.waitForEvent('page');
 
-    // プロジェクト選択
+    // Select project
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
     await page.waitForFunction(
       () => !!document.activeElement?.closest('.service-section')
     );
 
-    // サービス選択
+    // Select service
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
 
@@ -80,7 +80,7 @@ test.describe('Popup - プロジェクトあり', () => {
     expect(newPage.url()).toBeTruthy();
   });
 
-  test('P-5: 開いたタブの URL にプロジェクト ID が含まれる', async ({
+  test('P-5: opened tab URL contains the project ID', async ({
     context,
     popupUrl,
   }) => {
@@ -99,12 +99,12 @@ test.describe('Popup - プロジェクトあり', () => {
     await page.keyboard.press('Enter');
 
     const newPage = await newPagePromise;
-    // リダイレクト先でもデコードしたURLにプロジェクト ID が含まれること
+    // Check decoded URL to handle Google sign-in redirect
     const decodedUrl = decodeURIComponent(newPage.url());
     expect(decodedUrl).toContain(`project=${TEST_PROJECTS[0]}`);
   });
 
-  test('P-6: キーボードのみでポップアップを操作して GCP を開ける', async ({
+  test('P-6: popup can be completed with keyboard only', async ({
     context,
     popupUrl,
   }) => {
@@ -114,14 +114,14 @@ test.describe('Popup - プロジェクトあり', () => {
 
     const newPagePromise = context.waitForEvent('page');
 
-    // プロジェクト: 矢印キー → Enter
+    // Project: ArrowDown → Enter
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
     await page.waitForFunction(
       () => !!document.activeElement?.closest('.service-section')
     );
 
-    // サービス: 矢印キー → Enter
+    // Service: ArrowDown → Enter
     await page.keyboard.press('ArrowDown');
     await page.keyboard.press('Enter');
 
@@ -131,7 +131,7 @@ test.describe('Popup - プロジェクトあり', () => {
     expect(decodedUrl).toContain('project=');
   });
 
-  test('P-7: Settings ボタンでオプションページが開く', async ({
+  test('P-7: settings button opens the options page', async ({
     context,
     popupUrl,
     extensionId,

--- a/e2e/popup.spec.ts
+++ b/e2e/popup.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from './fixtures';
+
+// Must match src/utils/projects/Constant.ts
+const STORAGE_KEY_PROJECT_IDS = 'storageKeyProjectIDs';
+const TEST_PROJECTS = ['test-project-alpha', 'test-project-beta'];
+
+test.describe('Popup', () => {
+  test('project input is focused on open when projects exist', async ({
+    context,
+    extensionId,
+  }) => {
+    const popupUrl = `chrome-extension://${extensionId}/popup/popup.html`;
+
+    // Seed storage with test projects
+    const setupPage = await context.newPage();
+    await setupPage.goto(popupUrl);
+    await setupPage.evaluate(
+      ({ key, projects }) => chrome.storage.local.set({ [key]: projects }),
+      { key: STORAGE_KEY_PROJECT_IDS, projects: TEST_PROJECTS }
+    );
+    await setupPage.close();
+
+    // Open popup and verify focus
+    const page = await context.newPage();
+    await page.goto(popupUrl);
+    // Wait for chrome.storage async load + requestAnimationFrame
+    await page.waitForTimeout(1000);
+
+    const activeTag = await page.evaluate(() => document.activeElement?.tagName);
+    expect(activeTag).toBe('INPUT');
+  });
+
+  test('no focus error when no projects are registered', async ({
+    context,
+    extensionId,
+  }) => {
+    const popupUrl = `chrome-extension://${extensionId}/popup/popup.html`;
+
+    const page = await context.newPage();
+    await page.goto(popupUrl);
+    await page.waitForTimeout(1000);
+
+    // Should show no-projects message without errors
+    await expect(page.locator('.no-projects-message')).toBeVisible();
+  });
+});

--- a/e2e/popup.spec.ts
+++ b/e2e/popup.spec.ts
@@ -1,46 +1,150 @@
 import { test, expect } from './fixtures';
 
-// Must match src/utils/projects/Constant.ts
-const STORAGE_KEY_PROJECT_IDS = 'storageKeyProjectIDs';
 const TEST_PROJECTS = ['test-project-alpha', 'test-project-beta'];
 
-test.describe('Popup', () => {
-  test('project input is focused on open when projects exist', async ({
+test.describe('Popup - プロジェクト未登録', () => {
+  test('P-2: NoProjectsMessage が表示されフォーカスエラーが起きない', async ({
     context,
-    extensionId,
+    popupUrl,
   }) => {
-    const popupUrl = `chrome-extension://${extensionId}/popup/popup.html`;
-
-    // Seed storage with test projects
-    const setupPage = await context.newPage();
-    await setupPage.goto(popupUrl);
-    await setupPage.evaluate(
-      ({ key, projects }) => chrome.storage.local.set({ [key]: projects }),
-      { key: STORAGE_KEY_PROJECT_IDS, projects: TEST_PROJECTS }
-    );
-    await setupPage.close();
-
-    // Open popup and verify focus
     const page = await context.newPage();
     await page.goto(popupUrl);
-    // Wait for chrome.storage async load + requestAnimationFrame
     await page.waitForTimeout(1000);
+
+    await expect(page.locator('.no-projects-message')).toBeVisible();
+  });
+});
+
+test.describe('Popup - プロジェクトあり', () => {
+  test.beforeEach(async ({ seedProjects }) => {
+    await seedProjects(TEST_PROJECTS);
+  });
+
+  test('P-1: ポップアップを開くとプロジェクト入力欄に自動フォーカスされる', async ({
+    context,
+    popupUrl,
+  }) => {
+    const page = await context.newPage();
+    await page.goto(popupUrl);
+    await page.waitForFunction(() => document.activeElement?.tagName === 'INPUT');
 
     const activeTag = await page.evaluate(() => document.activeElement?.tagName);
     expect(activeTag).toBe('INPUT');
   });
 
-  test('no focus error when no projects are registered', async ({
+  test('P-3: プロジェクト選択後にサービス入力欄へフォーカスが移る', async ({
     context,
-    extensionId,
+    popupUrl,
   }) => {
-    const popupUrl = `chrome-extension://${extensionId}/popup/popup.html`;
-
     const page = await context.newPage();
     await page.goto(popupUrl);
-    await page.waitForTimeout(1000);
+    await page.waitForFunction(() => document.activeElement?.tagName === 'INPUT');
 
-    // Should show no-projects message without errors
-    await expect(page.locator('.no-projects-message')).toBeVisible();
+    // プロジェクトを選択（ArrowDown でドロップダウンを開き Enter で確定）
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+
+    // RAF によるフォーカス移動を待機
+    await page.waitForFunction(
+      () => !!document.activeElement?.closest('.service-section')
+    );
+
+    const isServiceFocused = await page.evaluate(
+      () => !!document.activeElement?.closest('.service-section')
+    );
+    expect(isServiceFocused).toBe(true);
+  });
+
+  test('P-4: プロジェクト＋サービス選択で新しいタブが開く', async ({
+    context,
+    popupUrl,
+  }) => {
+    const page = await context.newPage();
+    await page.goto(popupUrl);
+    await page.waitForFunction(() => document.activeElement?.tagName === 'INPUT');
+
+    const newPagePromise = context.waitForEvent('page');
+
+    // プロジェクト選択
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+    await page.waitForFunction(
+      () => !!document.activeElement?.closest('.service-section')
+    );
+
+    // サービス選択
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+
+    const newPage = await newPagePromise;
+    expect(newPage.url()).toBeTruthy();
+  });
+
+  test('P-5: 開いたタブの URL にプロジェクト ID が含まれる', async ({
+    context,
+    popupUrl,
+  }) => {
+    const page = await context.newPage();
+    await page.goto(popupUrl);
+    await page.waitForFunction(() => document.activeElement?.tagName === 'INPUT');
+
+    const newPagePromise = context.waitForEvent('page');
+
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+    await page.waitForFunction(
+      () => !!document.activeElement?.closest('.service-section')
+    );
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+
+    const newPage = await newPagePromise;
+    // リダイレクト先でもデコードしたURLにプロジェクト ID が含まれること
+    const decodedUrl = decodeURIComponent(newPage.url());
+    expect(decodedUrl).toContain(`project=${TEST_PROJECTS[0]}`);
+  });
+
+  test('P-6: キーボードのみでポップアップを操作して GCP を開ける', async ({
+    context,
+    popupUrl,
+  }) => {
+    const page = await context.newPage();
+    await page.goto(popupUrl);
+    await page.waitForFunction(() => document.activeElement?.tagName === 'INPUT');
+
+    const newPagePromise = context.waitForEvent('page');
+
+    // プロジェクト: 矢印キー → Enter
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+    await page.waitForFunction(
+      () => !!document.activeElement?.closest('.service-section')
+    );
+
+    // サービス: 矢印キー → Enter
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+
+    const newPage = await newPagePromise;
+    const decodedUrl = decodeURIComponent(newPage.url());
+    expect(decodedUrl).toContain('console.cloud.google.com');
+    expect(decodedUrl).toContain('project=');
+  });
+
+  test('P-7: Settings ボタンでオプションページが開く', async ({
+    context,
+    popupUrl,
+    extensionId,
+  }) => {
+    const page = await context.newPage();
+    await page.goto(popupUrl);
+    await page.waitForTimeout(500);
+
+    const newPagePromise = context.waitForEvent('page');
+    await page.locator('.settings-button').click();
+
+    const newPage = await newPagePromise;
+    expect(newPage.url()).toContain(`chrome-extension://${extensionId}`);
+    expect(newPage.url()).toContain('option');
   });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "GCP Selector",
-    "version": "1.0",
+    "version": "1.0.1",
     "description": "Jump to GCP console at once",
     "icons": {
         "16": "icons/icon16.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "GCP Selector",
-    "version": "1.0.1",
+    "version": "0.0.0",
     "description": "Jump to GCP console at once",
     "icons": {
         "16": "icons/icon16.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
+        "@playwright/test": "^1.60.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -1730,6 +1731,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -9894,6 +9911,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcp-selector",
-  "version": "1.0.1",
+  "version": "0.0.0",
   "description": "Select GCP project and service at once.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcp-selector",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Select GCP project and service at once.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "lint:fix": "eslint \"src/**/*.{js,jsx,ts,tsx}\" --fix",
     "format": "prettier --write src/**/*.{js,jsx,ts,tsx,css,html}",
     "format:check": "prettier --check src/**/*.{js,jsx,ts,tsx,css,html}",
-    "zip": "npm run build && zip -r gcp-selector.zip dist"
+    "zip": "npm run build && zip -r gcp-selector.zip dist",
+    "test:e2e": "npm run build && playwright test",
+    "test:e2e:ui": "npm run build && playwright test --ui"
   },
   "keywords": [],
   "author": "",
@@ -32,6 +34,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  // Extensions require headless: false
+  use: {
+    headless: false,
+  },
+  // Build the extension before running tests
+  webServer: undefined,
+});

--- a/src/option/Option.tsx
+++ b/src/option/Option.tsx
@@ -62,6 +62,7 @@ const Option: React.FC = () => {
           className="project-input"
           value={newProjectId}
           onChange={e => setNewProjectId(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && handleSave()}
           placeholder="Enter Project ID"
         />
         <button className="add-button" onClick={handleSave}>

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -22,6 +22,7 @@ const Popup: React.FC = () => {
     useRef<React.ComponentRef<typeof Select<SelectOption>>>(null);
   const projectSelectRef =
     useRef<React.ComponentRef<typeof Select<ProjectOption>>>(null);
+  const hasInitialFocus = useRef(false);
 
   const { projectIds } = useProjects();
   const { openGcpUrl } = useNavigation();
@@ -33,10 +34,13 @@ const Popup: React.FC = () => {
   }));
 
   useEffect(() => {
-    requestAnimationFrame(() => {
-      projectSelectRef.current?.focus();
-    });
-  }, []);
+    if (projectIds.length > 0 && !hasInitialFocus.current) {
+      hasInitialFocus.current = true;
+      requestAnimationFrame(() => {
+        projectSelectRef.current?.focus();
+      });
+    }
+  }, [projectIds]);
 
   const handleProjectSelect = (projectId: string) => {
     setSelectedProject(projectId);


### PR DESCRIPTION
## Summary

- `chrome.storage` の非同期ロード完了前に `requestAnimationFrame` が発火するレースコンディションにより、ポップアップを開いた際にプロジェクト入力欄へのフォーカスが当たらないことがあった問題を修正
- Playwright を導入し、Chrome 拡張機能の E2E テスト環境を整備
- Option ページで Enter キーによるプロジェクト追加が動作しなかった問題を合わせて修正

## Changes

### Bug Fix
- `useEffect` の依存配列を `[]` から `[projectIds]` に変更し、プロジェクトデータのロード完了後にフォーカスを当てるよう修正

### E2E Tests (Playwright)
- `e2e/fixtures.ts`: 拡張機能用カスタムフィクスチャ（`context`, `extensionId`, `popupUrl`, `optionUrl`, `seedProjects`）
- `e2e/popup.spec.ts`: Popup の動作テスト 7件（自動フォーカス、URL生成、キーボード操作、Settings 遷移など）
- `e2e/option.spec.ts`: Option ページのテスト 5件（CRUD、バリデーション、Enter キーなど）
- `e2e/integration.spec.ts`: ページ間連携テスト 3件（ストレージ経由の整合性確認）

### Minor Fix
- Option ページの入力欄に `onKeyDown` を追加し、Enter キーでプロジェクントを追加できるよう改善

## Test plan

- [x] `npm run test:e2e` で 15件全テストが PASS することを確認
- [x] Chrome に拡張機能を読み込み、ポップアップを開いたときにプロジェクト入力欄へ確実にフォーカスが当たることを確認
- [x] Option ページで Enter キーによるプロジェクト追加が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)